### PR TITLE
feat: add support for parsing remote GitHub repositories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ dirs = "5.0"
 ignore = "0.4"
 rayon = "1.10"
 serde = { version = "1.0", features = ["derive"] }
+tempfile = "3.10"
 thiserror = "1.0"
 tiktoken-rs = "0.5"
 toml = "0.8"

--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ Simply put: feed your entire repo to Gemini and let Claude Code have intelligent
 ### Ask Questions About Your Codebase
 
 ```bash
-# Analyze architecture
+# Analyze local architecture
 code-digest "What are the main architectural patterns used in this codebase?"
+
+# Analyze remote GitHub repository
+code-digest --repo https://github.com/owner/repo "How is this project structured?"
 
 # Understand dependencies
 code-digest "How does the authentication system interact with the database?"
@@ -36,6 +39,7 @@ code-digest "How can I implement the new feature X?"
 
 - **🚄 Blazing Fast**: Built in Rust with parallel processing
 - **🤖 Gemini Integration**: Direct piping to [Gemini CLI](https://github.com/reugn/gemini-cli) for instant AI analysis
+- **🔗 Remote Repository Support**: Analyze any GitHub repository directly without cloning
 - **📊 Smart Token Management**: Accurate token counting using tiktoken
 - **🎯 Intelligent Prioritization**: Automatically prioritizes important files when hitting token limits
 - **🔍 Git-Aware**: Respects `.gitignore` and custom `.digestignore` patterns
@@ -136,6 +140,7 @@ Arguments:
 
 Options:
   -d, --directory <PATH>      Directory to process [default: .]
+      --repo <URL>            GitHub repository URL (e.g., https://github.com/owner/repo)
   -o, --output <FILE>         Output to file instead of stdout
       --max-tokens <N>        Maximum tokens for output
   -q, --quiet                 Suppress output except errors
@@ -156,6 +161,15 @@ code-digest "Create a high-level architecture diagram of this codebase"
 ### Security Audit
 ```bash
 code-digest "Identify potential security vulnerabilities in this codebase"
+```
+
+### Analyze Remote Projects
+```bash
+# Analyze any public GitHub repository
+code-digest --repo https://github.com/rust-lang/rust "How is the compiler structured?"
+
+# Compare architectures
+code-digest --repo https://github.com/owner/project "Compare this architecture to best practices"
 ```
 
 ### Documentation Generation

--- a/src/config.rs
+++ b/src/config.rs
@@ -282,6 +282,7 @@ progress = true
         let mut cli_config = CliConfig {
             prompt: None,
             directories: vec![PathBuf::from(".")],
+            repo: None,
             output_file: None,
             max_tokens: None,
             llm_tool: LlmTool::default(),

--- a/src/core/digest.rs
+++ b/src/core/digest.rs
@@ -515,6 +515,7 @@ mod tests {
             verbose: false,
             config: None,
             progress: false,
+            repo: None,
         };
 
         let options = DigestOptions::from_config(&config).unwrap();

--- a/src/core/walker.rs
+++ b/src/core/walker.rs
@@ -392,6 +392,7 @@ mod tests {
             verbose: false,
             config: None,
             progress: false,
+            repo: None,
         };
 
         let options = WalkOptions::from_config(&config).unwrap();

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,0 +1,230 @@
+//! Remote repository fetching functionality
+
+use crate::utils::error::CodeDigestError;
+use std::path::PathBuf;
+use std::process::Command;
+use tempfile::TempDir;
+
+/// Check if gh CLI is available
+pub fn gh_available() -> bool {
+    Command::new("gh")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+/// Check if git is available
+pub fn git_available() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+/// Parse GitHub URL to extract owner and repo
+pub fn parse_github_url(url: &str) -> Result<(String, String), CodeDigestError> {
+    let url = url.trim_end_matches('/');
+
+    // Handle both https:// and http:// URLs
+    let parts: Vec<&str> = if url.starts_with("https://github.com/") {
+        url.strip_prefix("https://github.com/")
+            .ok_or_else(|| CodeDigestError::InvalidConfiguration("Invalid GitHub URL".to_string()))?
+            .split('/')
+            .collect()
+    } else if url.starts_with("http://github.com/") {
+        url.strip_prefix("http://github.com/")
+            .ok_or_else(|| CodeDigestError::InvalidConfiguration("Invalid GitHub URL".to_string()))?
+            .split('/')
+            .collect()
+    } else {
+        return Err(CodeDigestError::InvalidConfiguration(
+            "URL must start with https://github.com/ or http://github.com/".to_string(),
+        ));
+    };
+
+    if parts.len() < 2 {
+        return Err(CodeDigestError::InvalidConfiguration(
+            "GitHub URL must contain owner and repository name".to_string(),
+        ));
+    }
+
+    Ok((parts[0].to_string(), parts[1].to_string()))
+}
+
+/// Fetch a repository from GitHub
+pub fn fetch_repository(repo_url: &str, verbose: bool) -> Result<TempDir, CodeDigestError> {
+    let (owner, repo) = parse_github_url(repo_url)?;
+    let temp_dir = TempDir::new().map_err(|e| {
+        CodeDigestError::RemoteFetchError(format!("Failed to create temp directory: {}", e))
+    })?;
+
+    if verbose {
+        eprintln!("📥 Fetching repository: {}/{}", owner, repo);
+    }
+
+    // Try gh first, then fall back to git
+    let success = if gh_available() {
+        if verbose {
+            eprintln!("🔧 Using gh CLI for optimal performance");
+        }
+        clone_with_gh(&owner, &repo, temp_dir.path(), verbose)?
+    } else if git_available() {
+        if verbose {
+            eprintln!("🔧 Using git clone (gh CLI not available)");
+        }
+        clone_with_git(repo_url, temp_dir.path(), verbose)?
+    } else {
+        return Err(CodeDigestError::RemoteFetchError(
+            "Neither gh CLI nor git is available. Please install one of them.".to_string(),
+        ));
+    };
+
+    if !success {
+        return Err(CodeDigestError::RemoteFetchError("Failed to clone repository".to_string()));
+    }
+
+    if verbose {
+        eprintln!("✅ Repository fetched successfully");
+    }
+
+    Ok(temp_dir)
+}
+
+/// Clone repository using gh CLI
+fn clone_with_gh(
+    owner: &str,
+    repo: &str,
+    target_dir: &std::path::Path,
+    verbose: bool,
+) -> Result<bool, CodeDigestError> {
+    let repo_spec = format!("{}/{}", owner, repo);
+    let mut cmd = Command::new("gh");
+    cmd.arg("repo")
+        .arg("clone")
+        .arg(&repo_spec)
+        .arg(target_dir.join(repo))
+        .arg("--")
+        .arg("--depth")
+        .arg("1");
+
+    if verbose {
+        eprintln!("🔄 Running: gh repo clone {} --depth 1", repo_spec);
+    }
+
+    let output = cmd
+        .output()
+        .map_err(|e| CodeDigestError::RemoteFetchError(format!("Failed to run gh: {}", e)))?;
+
+    Ok(output.status.success())
+}
+
+/// Clone repository using git
+fn clone_with_git(
+    repo_url: &str,
+    target_dir: &std::path::Path,
+    verbose: bool,
+) -> Result<bool, CodeDigestError> {
+    let repo_name = repo_url.split('/').next_back().ok_or_else(|| {
+        CodeDigestError::InvalidConfiguration("Invalid repository URL".to_string())
+    })?;
+
+    let mut cmd = Command::new("git");
+    cmd.arg("clone").arg("--depth").arg("1").arg(repo_url).arg(target_dir.join(repo_name));
+
+    if verbose {
+        eprintln!("🔄 Running: git clone --depth 1 {}", repo_url);
+    }
+
+    let output = cmd
+        .output()
+        .map_err(|e| CodeDigestError::RemoteFetchError(format!("Failed to run git: {}", e)))?;
+
+    Ok(output.status.success())
+}
+
+/// Get the path to the cloned repository within the temp directory
+pub fn get_repo_path(temp_dir: &TempDir, repo_url: &str) -> Result<PathBuf, CodeDigestError> {
+    let (_, repo) = parse_github_url(repo_url)?;
+    let repo_path = temp_dir.path().join(&repo);
+
+    if !repo_path.exists() {
+        return Err(CodeDigestError::RemoteFetchError(format!(
+            "Repository directory not found after cloning: {}",
+            repo_path.display()
+        )));
+    }
+
+    Ok(repo_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_github_url_https() {
+        let (owner, repo) = parse_github_url("https://github.com/rust-lang/rust").unwrap();
+        assert_eq!(owner, "rust-lang");
+        assert_eq!(repo, "rust");
+    }
+
+    #[test]
+    fn test_parse_github_url_http() {
+        let (owner, repo) = parse_github_url("http://github.com/rust-lang/rust").unwrap();
+        assert_eq!(owner, "rust-lang");
+        assert_eq!(repo, "rust");
+    }
+
+    #[test]
+    fn test_parse_github_url_trailing_slash() {
+        let (owner, repo) = parse_github_url("https://github.com/rust-lang/rust/").unwrap();
+        assert_eq!(owner, "rust-lang");
+        assert_eq!(repo, "rust");
+    }
+
+    #[test]
+    fn test_parse_github_url_invalid() {
+        assert!(parse_github_url("https://gitlab.com/rust-lang/rust").is_err());
+        assert!(parse_github_url("not-a-url").is_err());
+        assert!(parse_github_url("https://github.com/").is_err());
+        assert!(parse_github_url("https://github.com/rust-lang").is_err());
+    }
+
+    #[test]
+    fn test_gh_available() {
+        // This test will pass or fail depending on the environment
+        // We just ensure it doesn't panic
+        let _ = gh_available();
+    }
+
+    #[test]
+    fn test_git_available() {
+        // This test will pass or fail depending on the environment
+        // We just ensure it doesn't panic
+        let _ = git_available();
+    }
+
+    #[test]
+    fn test_get_repo_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_url = "https://github.com/owner/repo";
+
+        // Create the expected directory
+        std::fs::create_dir_all(temp_dir.path().join("repo")).unwrap();
+
+        let path = get_repo_path(&temp_dir, repo_url).unwrap();
+        assert_eq!(path, temp_dir.path().join("repo"));
+    }
+
+    #[test]
+    fn test_get_repo_path_not_found() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_url = "https://github.com/owner/repo";
+
+        // Don't create the directory
+        let result = get_repo_path(&temp_dir, repo_url);
+        assert!(result.is_err());
+    }
+}

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -53,6 +53,10 @@ pub enum CodeDigestError {
     #[error("Invalid glob pattern: {0}")]
     InvalidGlobPattern(String),
 
+    /// Remote repository errors
+    #[error("Remote fetch error: {0}")]
+    RemoteFetchError(String),
+
     /// General I/O errors
     #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -36,3 +36,33 @@ fn test_llm_tool_install_instructions() {
     assert!(LlmTool::Gemini.install_instructions().contains("pip install"));
     assert!(LlmTool::Codex.install_instructions().contains("github.com"));
 }
+
+#[test]
+fn test_repo_argument() {
+    let config = Config::parse_from(["code-digest", "--repo", "https://github.com/owner/repo"]);
+    assert_eq!(config.repo, Some("https://github.com/owner/repo".to_string()));
+}
+
+#[test]
+fn test_repo_and_directory_mutually_exclusive() {
+    let result = Config::try_parse_from([
+        "code-digest",
+        "--repo",
+        "https://github.com/owner/repo",
+        "-d",
+        ".",
+    ]);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("cannot be used with"));
+}
+
+#[test]
+fn test_valid_repo_url_accepted() {
+    let config = Config::parse_from([
+        "code-digest",
+        "--repo",
+        "https://github.com/matiasvillaverde/code-digest",
+    ]);
+    assert_eq!(config.repo, Some("https://github.com/matiasvillaverde/code-digest".to_string()));
+}


### PR DESCRIPTION
## Summary

This PR implements remote GitHub repository parsing functionality as requested in #2.

### Key Features
- **New `--repo` CLI argument** for specifying GitHub repository URLs
- **Smart tool detection** with `gh` CLI preferred, fallback to `git clone`  
- **Performance optimized** using shallow clones (`--depth 1`)
- **Comprehensive testing** including integration and acceptance tests
- **Full documentation** updated with examples and usage

### Implementation Details
- **Mutually exclusive arguments**: `--repo` and `-d/--directories` cannot be used together
- **URL validation**: Only accepts `https://github.com/` and `http://github.com/` URLs
- **Temporary directory management**: Uses `tempfile::TempDir` for automatic cleanup
- **Error handling**: Clear error messages for missing tools or invalid URLs
- **Existing pipeline integration**: Reuses all existing file processing logic

### Testing Coverage
- ✅ Unit tests for URL parsing and validation
- ✅ Integration tests with mocked `gh` and `git` commands  
- ✅ CLI argument validation tests
- ✅ Acceptance test using the project's own repository
- ✅ Error scenarios (invalid URLs, missing tools)

### Usage Examples
```bash
# Analyze a remote repository
code-digest --repo https://github.com/rust-lang/rust

# Analyze with a prompt
code-digest --repo https://github.com/owner/repo "Find security issues"

# Output to file
code-digest --repo https://github.com/owner/repo -o analysis.md
```

### Performance
- Uses shallow clones for minimal data transfer
- Leverages `gh` CLI when available for optimal GitHub integration
- Automatic cleanup of temporary directories

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)