### PR TITLE
feat: add --include flag support for directory specification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-digest"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "High-performance CLI tool to convert codebases to Markdown for LLM context"
 authors = ["Matias Villaverde"]

--- a/README.md
+++ b/README.md
@@ -71,14 +71,29 @@ npm install -g @google/gemini-cli
 gcloud auth application-default login
 ```
 
+### More Usage Examples
+
+```bash
+# Save to file for later use
+code-digest -o context.md
+
+# Process specific directories (positional arguments)
+code-digest src/ tests/ docs/
+
+# Process specific directories (explicit include flags)
+code-digest --include src/ --include tests/ --include docs/
+
+# Process with token limit
+code-digest --include src/ --max-tokens 100000
+```
+
 ## Configuration
 
-Fine-tune how `code-digest` processes your repository.
+Fine-tune how `code-digest` processes your repository:
 
   * **`.digestignore`:** Exclude non-essential files and folders (e.g., `node_modules/`, `target/`).
   * **`.digestkeep`:** Prioritize critical files (e.g., `src/main.rs`, `Cargo.toml`). This ensures the most important code is included when you're near the token limit.
   * **`.code-digest.toml`:** For advanced configuration like setting default token limits and priority weights.
-## Configuration
 
 ### .digestignore
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -286,6 +286,7 @@ progress = true
         let mut cli_config = CliConfig {
             prompt: None,
             paths: Some(vec![PathBuf::from(".")]),
+            include: None,
             repo: None,
             read_stdin: false,
             output_file: None,

--- a/src/core/digest.rs
+++ b/src/core/digest.rs
@@ -630,6 +630,9 @@ mod tests {
         let config = Config {
             prompt: None,
             paths: Some(vec![temp_dir.path().to_path_buf()]),
+            include: None,
+            repo: None,
+            read_stdin: false,
             output_file: None,
             max_tokens: Some(100000),
             llm_tool: crate::cli::LlmTool::default(),
@@ -637,8 +640,6 @@ mod tests {
             verbose: false,
             config: None,
             progress: false,
-            repo: None,
-            read_stdin: false,
             copy: false,
             enhanced_context: false,
             custom_priorities: vec![],

--- a/src/core/walker.rs
+++ b/src/core/walker.rs
@@ -483,6 +483,7 @@ mod tests {
         let config = Config {
             prompt: None,
             paths: Some(vec![temp_dir.path().to_path_buf()]),
+            include: None,
             output_file: None,
             max_tokens: None,
             llm_tool: crate::cli::LlmTool::default(),
@@ -735,6 +736,7 @@ mod tests {
         let mut config = crate::cli::Config {
             prompt: None,
             paths: Some(vec![root.to_path_buf()]),
+            include: None,
             repo: None,
             read_stdin: false,
             output_file: None,
@@ -799,6 +801,7 @@ mod tests {
         let mut config = crate::cli::Config {
             prompt: None,
             paths: Some(vec![temp_dir.path().to_path_buf()]),
+            include: None,
             repo: None,
             read_stdin: false,
             output_file: None,
@@ -839,6 +842,7 @@ mod tests {
         let mut config = crate::cli::Config {
             prompt: None,
             paths: Some(vec![temp_dir.path().to_path_buf()]),
+            include: None,
             repo: None,
             read_stdin: false,
             output_file: None,
@@ -878,6 +882,7 @@ mod tests {
         let mut config = crate::cli::Config {
             prompt: None,
             paths: Some(vec![temp_dir.path().to_path_buf()]),
+            include: None,
             repo: None,
             read_stdin: false,
             output_file: None,
@@ -923,6 +928,7 @@ mod tests {
         let mut config = crate::cli::Config {
             prompt: None,
             paths: Some(vec![temp_dir.path().to_path_buf()]),
+            include: None,
             repo: None,
             read_stdin: false,
             output_file: None,


### PR DESCRIPTION
## Summary

- Implements `--include` flag as an alternative to positional arguments for directory specification
- Maintains full backward compatibility with existing positional argument syntax
- Adds comprehensive test coverage and validation for new functionality

Closes #17

## Changes Made

### Core CLI Functionality
- Added `include: Option<Vec<PathBuf>>` field to Config struct in `src/cli.rs`
- Extended ArgGroup to enforce mutual exclusion between positional arguments and include flags
- Updated `get_directories()` method to prioritize include paths when specified
- Added developer guidance comments for future maintainers

### Test Coverage
- Added 8 comprehensive tests covering all include flag scenarios
- Tests validate single/multiple paths, conflict detection, and validation errors
- Includes edge case testing for file path validation

### Documentation
- Updated help text examples in CLI configuration
- Enhanced README.md with clear usage examples showing both approaches
- Maintained backward compatibility in all documentation

### Implementation Details
- Uses clap's ArgGroup for clean mutual exclusion enforcement
- Follows existing code patterns and maintains consistency
- All validation logic properly handles include paths

## Test Plan

- [x] All existing tests continue to pass
- [x] New include flag functionality works as specified
- [x] Mutual exclusion properly prevents conflicting arguments
- [x] Validation correctly handles file vs directory paths
- [x] Backward compatibility maintained for all existing usage patterns
- [x] Help text accurately reflects functionality

🤖 Generated with [Claude Code](https://claude.ai/code)